### PR TITLE
add feature extractor wip

### DIFF
--- a/dataset_loader.py
+++ b/dataset_loader.py
@@ -1,0 +1,56 @@
+from typing import Optional
+
+import numpy as np
+import os
+from sympy.printing.pytorch import torch
+from torchvision import transforms
+from torch.utils.data import Dataset, DataLoader
+from PIL import Image
+from glob import glob
+
+class DeepGlobeDataset(Dataset):
+    def __init__(self, data_dir, class_rgb_values, img_size: Optional[tuple[int, int]] = None):
+        self.image_paths = sorted(glob(os.path.join(data_dir, '*_sat.jpg')))
+        self.mask_paths  = sorted(glob(os.path.join(data_dir, '*_mask.png')))
+        self.class_rgb_values = class_rgb_values
+        self.img_size = img_size  # (W, H)
+
+    def __len__(self):
+        return len(self.image_paths)
+
+    def __getitem__(self, idx):
+        """
+        Load the image and mask at index `idx`, resize them, and convert to tensors.
+        """
+        # --- Load & resize images ---
+        img = Image.open(self.image_paths[idx]).convert('RGB')
+        if self.img_size is not None:
+            img = img.resize(self.img_size, resample=Image.Resampling.BILINEAR)
+        img_rgb = np.array(img) # needed for SLIC
+
+        mask = Image.open(self.mask_paths[idx]).convert('RGB')
+        if self.img_size is not None:
+            mask = mask.resize(self.img_size, resample=Image.Resampling.NEAREST)
+
+        # --- transform to tensors and preprocess ---
+        prepoc = transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.485, 0.456, 0.406),
+                                 (0.229, 0.224, 0.225)),
+        ])
+        img_t = prepoc(img)
+
+        mask_np = np.array(mask)                   # (H,W,3), uint8
+        mask_np = self.rgb_to_class(mask_np)  # (H,W), uint8
+        mask_t = torch.from_numpy(mask_np).long()  # (H,W), int64
+
+        return img_t, img_rgb, mask_t
+
+    def rgb_to_class(self, mask):
+        """
+        Convert (H, W, 3) RGB mask to (H, W) class-index mask.
+        """
+        semantic_map = np.zeros(mask.shape[:2], dtype=np.uint8)
+        for idx, color in enumerate(self.class_rgb_values):
+            semantic_map[np.all(mask == color, axis=-1)] = idx
+        return semantic_map

--- a/feature_extractor.py
+++ b/feature_extractor.py
@@ -1,0 +1,59 @@
+from typing import Sequence, Tuple, List
+
+import torch
+import torch.nn.functional as F
+from torchgeo.models import resnet50, ResNet50_Weights
+from skimage.segmentation import slic
+import numpy as np
+
+@torch.inference_mode()
+def extract_features(
+    img_t: torch.Tensor,          # [3,H,W] or [1,3,H,W], normalized
+    img_rgb: np.ndarray | None,   # [H,W,3] uint8; if None, we’ll reconstruct from img_t
+    k: int = 500,
+    device: str | torch.device = "cpu",
+):
+    """
+    Returns:
+        X:  torch.FloatTensor [N, 2048]  superpixel features
+        sp: np.ndarray [H, W]            superpixel labels (0..N-1)
+    """
+    if img_t.ndim == 3:
+        x = img_t.unsqueeze(0)                  # [1,3,H,W]
+    elif img_t.ndim == 4:
+        x = img_t                               # [N,3,H,W] (assume N==1 for this function)
+
+    # Move to device & get H,W
+    x = x.to(device)
+    _, _, H, W = x.shape
+
+    # 1) Backbone
+    backbone = resnet50(
+        weights=ResNet50_Weights.FMOW_RGB_GASSL,
+        num_classes=0,
+        global_pool="",
+    ).to(device).eval()
+
+    Fm = backbone(x)               # [1, 2048, h, w]
+    _, C, h, w = Fm.shape
+    Fm = Fm[0]                     # [2048, h, w]
+
+    sp = slic(img_rgb, n_segments=k, compactness=10, start_label=0)  # [H,W]
+    N = int(sp.max()) + 1
+
+    # 3) Downsample superpixel map to (h,w) and masked mean pooling
+    sp_small = torch.from_numpy(sp)[None, None].float().to(device)   # [1,1,H,W]
+    sp_small = F.interpolate(sp_small, size=(h, w), mode="nearest")[0, 0].long()  # [h,w]
+
+    F_flat = Fm.reshape(C, -1)             # [C, h*w]
+    sp_flat = sp_small.reshape(-1)         # [h*w]
+
+    ones = torch.ones(h * w, dtype=F_flat.dtype, device=device)
+    denom = torch.zeros(N, dtype=F_flat.dtype, device=device).scatter_add_(0, sp_flat, ones) + 1e-6  # [N]
+
+    X = torch.zeros(N, C, dtype=F_flat.dtype, device=device)
+    idx = sp_flat.unsqueeze(0).expand(C, -1)           # [C, h*w]
+    X.scatter_add_(0, idx.T, F_flat.T)                 # sum features per SP
+    X = (X.T / denom).T                                # mean -> [N, 2048]
+
+    return X.cpu(), sp

--- a/load_palette.py
+++ b/load_palette.py
@@ -1,0 +1,16 @@
+import csv
+from pathlib import Path
+
+def load_class_palette(csv_path: str):
+    """Return (names, class_rgb_values, unknown_index)."""
+    names, class_rgb_values = [], []
+    unknown_index = None
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for i, row in enumerate(reader):
+            names.append(row["name"])
+            rgb = (int(row["r"]), int(row["g"]), int(row["b"]))
+            class_rgb_values.append(rgb)
+            if row["name"].lower() == "unknown":
+                unknown_index = i
+    return names, class_rgb_values, unknown_index

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ numpy
 pandas
 torch
 torchvision
+torchgeo
 scikit-image

--- a/tests/test_feature_extractor.py
+++ b/tests/test_feature_extractor.py
@@ -1,0 +1,69 @@
+from skimage.measure import regionprops
+import torch
+import torch.nn.functional as F
+import matplotlib.pyplot as plt
+from skimage.segmentation import mark_boundaries
+from feature_extractor import extract_features       # the version that accepts img_t (+ optionally img_rgb)
+from dataset_loader import DeepGlobeDataset                  # adjust import to your path
+from load_palette import load_class_palette           # if you use the CSV palette
+import pandas as pd
+
+# --- Config ---
+data_dir = "../data/train"
+k = 250
+
+# --- Load class palette (optional, if your dataset needs it) ---
+# CSV: name,r,g,b
+names, class_rgb_values, _unknown = load_class_palette("../data/class_dict.csv")
+
+# --- Build dataset & dataloader ---
+ds = DeepGlobeDataset(data_dir, class_rgb_values)
+
+target_name = "6399_sat.jpg"
+idx = next(i for i, p in enumerate(ds.image_paths) if target_name in p)
+
+img_t, img_rgb, mask_t = ds[idx]
+X, sp = extract_features(img_t, img_rgb, k=k)
+# ------------- Inspect -------------
+print(f"Superpixels: {sp.max() + 1}")
+print(f"Feature matrix shape: {tuple(X.shape)}")
+print(f"First feature vector (first 10 dims):\n{X[0, :10]}")
+
+# ------------- Visualization with labels -------------
+plt.figure(figsize=(10, 10))
+plt.imshow(mark_boundaries(img_rgb, sp, color=(1, 0, 0)))
+plt.title("SLIC Superpixels with IDs")
+plt.axis("off")
+
+regions = regionprops(sp + 1)
+for r in regions:
+    cy, cx = r.centroid
+    sp_id = r.label - 1
+    plt.text(
+        cx, cy, str(sp_id),
+        color="yellow", fontsize=8,
+        ha="center", va="center",
+        bbox=dict(facecolor="black", alpha=0.5, boxstyle="round,pad=0.2")
+    )
+
+plt.show()
+
+# ------------- Cosine similarities -------------
+pick_ids = [52, 38, 151, 103]
+
+Xn = F.normalize(X.float(), dim=1)
+
+# Build the similarity matrix
+sim_matrix = torch.zeros((len(pick_ids), len(pick_ids)))
+for i_idx, i in enumerate(pick_ids):
+    for j_idx, j in enumerate(pick_ids):
+        if i == j:
+            sim_matrix[i_idx, j_idx] = 1.0  # self-similarity
+        else:
+            sim_matrix[i_idx, j_idx] = torch.dot(Xn[i], Xn[j]).item()
+
+df = pd.DataFrame(sim_matrix.numpy(), index=pick_ids, columns=pick_ids)
+df = df.round(3)
+
+print("\nPairwise cosine similarity matrix:")
+print(df.to_string())


### PR DESCRIPTION
started to separate the logic in different files to make the project easier to work with.
- moved dataset loading code in `dataset_loader.py`; it will output an image tensor, image rgb (needed for SLIC) and mask tensor
- `extract_features` in `feature_extractor.py` will accept a batch and return a feature vector with 2048 features, calculated using a ResNet50 backbone. to extract features per superpixels we just use mean pooling over the pixels it covers.
- `tests/test_feature_extractor.py` has a small experiment to test how the feature extraction works. we took a sample image and calculated the cosine similarity of some pixels

<img width="609" height="611" alt="image" src="https://github.com/user-attachments/assets/7ee8a928-e1cd-4cbe-8de1-590a11a07cd2" />

<img width="314" height="176" alt="image" src="https://github.com/user-attachments/assets/ca28ffcd-3ea7-485a-b941-33d63a9c2bb6" />
